### PR TITLE
improve compatibility with Amazon Vine Helper: keep fading

### DIFF
--- a/src/amazon-vine-enhancer.user.js
+++ b/src/amazon-vine-enhancer.user.js
@@ -278,7 +278,7 @@ TODO:
     }`,
       //Fade/Dim tiles
       `.VINE-UIE-dimmed-tile {
-      opacity: .25;
+      opacity: .25 !important;
       transition: opacity 300ms;
    }`,
       //hide tiles completely


### PR DESCRIPTION
As [mentioned here](https://github.com/ChrisMBarr/UserScripts/issues/2#issuecomment-2220770578):

The `!important` here makes the "dimmed" status stick, which otherwise is overridden by the *Amazon Vine Helper* addon. This way one can dim terms that might lead to "false positives" with the `amazon-vine-enhancer.user.js` script, while permanently remove "safe hits" with the *Amazon Vine Helper* addon 😃